### PR TITLE
Fix TypeError: PubSub is not a constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "standard-version": "^4.4.0"
   },
   "peerDependencies": {
-    "@google-cloud/pubsub": "^0.20.1"
+    "@google-cloud/pubsub": "^0.21.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "standard-version": "^4.4.0"
   },
   "peerDependencies": {
-    "@google-cloud/pubsub": "^0.21.1"
+    "@google-cloud/pubsub": "^0.22.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ npm install google-pubsub-emulator --save-dev
 I think the package is the most suitable for unit testing.
  
 ```javascript
-const pubsub = require('@google-cloud/pubsub');
+const {PubSub} = require('@google-cloud/pubsub');
 const Emulator = require('google-pubsub-emulator');
 
 describe('test suit', ()=>{

--- a/src/pubsub-emulator.js
+++ b/src/pubsub-emulator.js
@@ -287,7 +287,7 @@ class PubSubEmulator{
 
   _getPubSubClient (options) {
     if (this._pubsub === null) {
-      const PubSub = require('@google-cloud/pubsub');
+      const {PubSub} = require('@google-cloud/pubsub');
       options = options || {};
       this._pubsub = new PubSub(options);
     }

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PubSub = require('@google-cloud/pubsub');
+const {PubSub} = require('@google-cloud/pubsub');
 const Emulator = require('../index');
 const chai = require('chai');
 const fs = require('fs');


### PR DESCRIPTION
There was a breaking change in `@google-cloud/pubsub`. It now uses ES6 import/export syntax since v0.21.0.
https://github.com/googleapis/nodejs-pubsub/blob/master/CHANGELOG.md

Fixes #12