### PR TITLE
fix: required @google-cloud/pubsub@2.16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "standard-version": "^9.0.0"
   },
   "peerDependencies": {
-    "@google-cloud/pubsub": "^0.28.1"
+    "@google-cloud/pubsub": "^2.16.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: because major version number changed